### PR TITLE
fix requirement - keystone uses PyPAM and not old pam module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # keystone dependencies
 d2to1>=0.2.10,<0.3
 pbr>=0.5,<0.6
-pam>=0.1.4
+PyPam>=0.5.0
 WebOb>=1.0.8
 eventlet
 greenlet


### PR DESCRIPTION
This fixes a dependency issue.  keystone uses the new PyPAM module and not pam, but the requirements were still pointing to pam.
