### PR TITLE
Updated get_all and _get_enabled in core.py

### DIFF
--- a/keystone/common/ldap/core.py
+++ b/keystone/common/ldap/core.py
@@ -1800,10 +1800,20 @@ class EnabledEmuMixIn(BaseLdap):
                            utf8_decode(naming_rdn[1]))
         self.enabled_emulation_naming_attr = naming_attr
 
-    def _get_enabled(self, object_id):
+    def _get_enabled(self, object_id, conn=None):
         dn = self._id_to_dn(object_id)
         query = '(member=%s)' % dn
-        with self.get_connection() as conn:
+        if conn is None:
+            with self.get_connection() as conn:
+                try:
+                    enabled_value = conn.search_s(self.enabled_emulation_dn,
+                                                  ldap.SCOPE_BASE,
+                                                  query, ['cn'])
+                except ldap.NO_SUCH_OBJECT:
+                    return False
+                else:
+                    return bool(enabled_value)
+        else:
             try:
                 enabled_value = conn.search_s(self.enabled_emulation_dn,
                                               ldap.SCOPE_BASE,
@@ -1863,8 +1873,9 @@ class EnabledEmuMixIn(BaseLdap):
             tenant_list = [self._ldap_res_to_model(x)
                            for x in self._ldap_get_all(ldap_filter)
                            if x[0] != self.enabled_emulation_dn]
-            for tenant_ref in tenant_list:
-                tenant_ref['enabled'] = self._get_enabled(tenant_ref['id'])
+            with self.get_connection() as conn:
+                for tenant_ref in tenant_list:
+                    tenant_ref['enabled'] = self._get_enabled(tenant_ref['id'],conn)
             return tenant_list
         else:
             return super(EnabledEmuMixIn, self).get_all(ldap_filter)


### PR DESCRIPTION
LDAP being enabled, any keystone commands that use get_all takes a lot of time, especially if there are many LDAP users (like ~3000), due to the fact that _get_enabled makes a new connection for each user. Instead, I thought it would be better if a connection is made before the for loop in get_all, get all "enabled" values from all users, and then close the connection. I actually tested this code change on mine, and it actually speeds up many keystone commands (user-list, user-role-add, user-delete, user-get). Before it took about 50 seconds, but now, it takes about 4 seconds.