### PR TITLE
Fix typo in docs

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -39,7 +39,7 @@ this would be accomplished by:
 
 .. code-block:: bash
 
-    $ sysctl -w 'sys.net.ipv4.ip_local_reserved_ports=35357'
+    $ sysctl -w 'net.ipv4.ip_local_reserved_ports=35357'
 
 To make the above change persistent,
 ``net.ipv4.ip_local_reserved_ports = 35357`` should be added to


### PR DESCRIPTION
Fixes error:

    # sysctl -w 'sys.net.ipv4.ip_local_reserved_ports=35357'
    sysctl: cannot stat /proc/sys/sys/net/ipv4/ip_local_reserved_ports: No such file or directory

The new command works:

    # sysctl -w 'net.ipv4.ip_local_reserved_ports=35357'    
    net.ipv4.ip_local_reserved_ports = 35357