### PR TITLE
Example Hybrid Providers

### DIFF
--- a/keystone/token/provider.py
+++ b/keystone/token/provider.py
@@ -102,9 +102,8 @@ class Manager(manager.Manager):
                 notifications.register_event_callback(event, resource_type,
                                                       callback_fns)
 
-    @property
-    def _needs_persistence(self):
-        return self.driver.needs_persistence()
+    def _needs_persistence(self, token=None):
+        return self.driver.needs_persistence(token=token)
 
     @property
     def _persistence(self):
@@ -165,7 +164,7 @@ class Manager(manager.Manager):
             # to fetch from the backend (the driver persists the token).
             # Otherwise the information about the token must be in the token
             # id.
-            if self._needs_persistence:
+            if self._needs_persistence():
                 token_ref = self._persistence.get_token(token_id)
                 # Overload the token_id variable to be a token reference
                 # instead.
@@ -220,7 +219,7 @@ class Manager(manager.Manager):
             user_id, method_names, expires_at, project_id, domain_id,
             auth_context, trust, include_catalog, parent_audit_id)
 
-        if self._needs_persistence:
+        if self._needs_persistence():
             data = dict(key=token_id,
                         id=token_id,
                         expires=token_data['token']['expires_at'],
@@ -267,7 +266,7 @@ class Manager(manager.Manager):
         else:
             self.revoke_api.revoke_by_audit_id(token_ref.audit_id)
 
-        if CONF.token.revoke_by_id and self._needs_persistence:
+        if CONF.token.revoke_by_id and self._needs_persistence():
             self._persistence.delete_token(token_id=token_id)
 
         # FIXME(morganfainberg): Does this cache actually need to be

--- a/keystone/token/providers/common.py
+++ b/keystone/token/providers/common.py
@@ -532,7 +532,8 @@ class BaseProvider(base.Provider):
         access_token = None  # dictionary containing OAUTH1 information
         trust_ref = None  # dictionary containing trust scope
         token_dict = None  # existing token information
-        if self.needs_persistence():
+        print token_id
+        if self.needs_persistence(token=token_id):
             token_ref = token_id
             token_data = token_ref.get('token_data')
             user_id = token_ref['user_id']

--- a/keystone/token/providers/fernet/core.py
+++ b/keystone/token/providers/fernet/core.py
@@ -46,7 +46,7 @@ class Provider(common.BaseProvider):
 
         self.token_formatter = tf.TokenFormatter()
 
-    def needs_persistence(self):
+    def needs_persistence(self, token=None):
         """Should the token be written to a backend."""
         return False
 

--- a/keystone/token/providers/uuid.py
+++ b/keystone/token/providers/uuid.py
@@ -44,6 +44,6 @@ class Provider(common.BaseProvider):
         """
         return True
 
-    def needs_persistence(self):
+    def needs_persistence(self, token=None):
         """Should the token be written to a backend."""
         return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -160,6 +160,8 @@ keystone.token.persistence =
 keystone.token.provider =
     fernet = keystone.token.providers.fernet:Provider
     uuid = keystone.token.providers.uuid:Provider
+    hybrid_uuid = keystone.token.providers.hybrid_uuid_provider:Provider
+    hybrid_fernet = keystone.token.providers.hybrid_fernet_provider:Provider
 
 keystone.trust =
     sql = keystone.trust.backends.sql:Trust


### PR DESCRIPTION
This change details the work I had to do to the upstream
implementation to write two providers that provided a seamless
migration from uuid tokens to fernet tokens.

Change-Id: Ic336a4c6a94bc9121a0f08a4fd6ab04c265f19e2