### PR TITLE
[dev_master][replace os.urandom with secrets.token_bytes]

### DIFF
--- a/keystone/api/users.py
+++ b/keystone/api/users.py
@@ -14,6 +14,7 @@
 
 import base64
 import os
+import secrets
 import uuid
 
 import flask
@@ -577,7 +578,7 @@ class UserAppCredListCreateResource(ks_flask.ResourceBase):
     @staticmethod
     def _generate_secret():
         length = 64
-        secret = os.urandom(length)
+        secret = secrets.token_bytes(length)
         secret = base64.urlsafe_b64encode(secret)
         secret = secret.rstrip(b'=')
         secret = secret.decode('utf-8')

--- a/keystone/common/cache/core.py
+++ b/keystone/common/cache/core.py
@@ -15,6 +15,7 @@
 """Keystone Caching Layer Implementation."""
 
 import os
+import secrets
 
 from dogpile.cache import region
 from dogpile.cache import util
@@ -36,7 +37,7 @@ class RegionInvalidationManager(object):
         self._region_key = self.REGION_KEY_PREFIX + region_name
 
     def _generate_new_id(self):
-        return os.urandom(10)
+        return secrets.token_bytes(10)
 
     @property
     def region_id(self):

--- a/keystone/tests/unit/core.py
+++ b/keystone/tests/unit/core.py
@@ -18,6 +18,8 @@ import datetime
 import functools
 import hashlib
 import json
+import secrets
+
 import ldap
 import os
 import shutil
@@ -422,9 +424,9 @@ def new_ec2_credential(user_id, project_id=None, blob=None, **kwargs):
 
 def new_totp_credential(user_id, project_id=None, blob=None):
     if not blob:
-        # NOTE(notmorgan): 20 bytes of data from os.urandom for
+        # NOTE(notmorgan): 20 bytes of data from secrets.token_bytes for
         # a totp secret.
-        blob = base64.b32encode(os.urandom(20)).decode('utf-8')
+        blob = base64.b32encode(secrets.token_bytes(20)).decode('utf-8')
     credential = new_credential_ref(user_id=user_id,
                                     project_id=project_id,
                                     blob=blob,


### PR DESCRIPTION
os.urandom function not safe, as python version 3.6 , we can replace it with secrets.token_bytes