### PR TITLE
Fixed mariadb env vars in oidc plugin docker-compose file

### DIFF
--- a/devstack/tools/oidc/docker-compose.yaml
+++ b/devstack/tools/oidc/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
   keycloak-database:
     image: quay.io/metal3-io/mariadb:latest
     environment:
-      MYSQL_ROOT_PASSWORD: nomoresecret
-      MYSQL_DATABASE: keycloak
-      MYSQL_USER: keycloak
-      MYSQL_PASSWORD: nomoresecret
+      MARIADB_ROOT_PASSWORD: nomoresecret
+      MARIADB_DATABASE: keycloak
+      MARIADB_USER: keycloak
+      MARIADB_PASSWORD: nomoresecret


### PR DESCRIPTION
The current environment variable names in the docker-compose file will not work with the mariadb container hosted by quay.io.
This is because the container's entry point specifically looks for variables prefixed with MARIADB, not MYSQL.