### PR TITLE
Prevent unauthorized EC2 credential creation and deletion

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -2,3 +2,4 @@
 host=review.opendev.org
 port=29418
 project=openstack/keystone.git
+defaultbranch=stable/yoga

--- a/.gitreview
+++ b/.gitreview
@@ -2,4 +2,4 @@
 host=review.opendev.org
 port=29418
 project=openstack/keystone.git
-defaultbranch=stable/yoga
+defaultbranch=unmaintained/yoga

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -147,61 +147,6 @@
         shared:
           MULTI_KEYSTONE: True
 
-# Experimental
-- job:
-    name: keystone-dsvm-functional-federation-centos7
-    parent: keystone-dsvm-functional
-    nodeset: devstack-single-node-centos-7
-    vars:
-      devstack_localrc:
-        TEMPEST_PLUGINS: '/opt/stack/keystone-tempest-plugin'
-      devstack_services:
-        keystone-saml2-federation: true
-        tls-proxy: false
-      devstack_plugins:
-        keystone: https://opendev.org/openstack/keystone
-      zuul_copy_output:
-        /etc/shibboleth: logs
-
-# Experimental
-- job:
-    name: keystone-dsvm-functional-federation-ubuntu-xenial
-    parent: keystone-dsvm-functional
-    nodeset: openstack-single-node-xenial
-    vars:
-      devstack_localrc:
-        TEMPEST_PLUGINS: '/opt/stack/keystone-tempest-plugin'
-      devstack_services:
-        keystone-saml2-federation: true
-        tls-proxy: false
-      devstack_plugins:
-        keystone: https://opendev.org/openstack/keystone
-      zuul_copy_output:
-        /etc/shibboleth: logs
-
-# Experimental
-- job:
-    name: keystone-dsvm-py35-functional-federation-ubuntu-xenial
-    parent: keystone-dsvm-functional-federation
-    vars:
-      devstack_localrc:
-        TEMPEST_PLUGINS: '/opt/stack/keystone-tempest-plugin'
-        USE_PYTHON3: True
-      zuul_copy_output:
-        /etc/shibboleth: logs
-
-# Experimental
-# Transitional rename
-- job:
-    name: keystone-dsvm-functional-federation
-    parent: keystone-dsvm-functional-federation-ubuntu-xenial
-
-# Experimental
-# Transitional rename
-- job:
-    name: keystone-dsvm-py35-functional-federation
-    parent: keystone-dsvm-py35-functional-federation-ubuntu-xenial
-
 - project:
     templates:
       - openstack-cover-jobs
@@ -273,9 +218,3 @@
             irrelevant-files: *irrelevant-files
         - tempest-pg-full:
             irrelevant-files: *tempest-irrelevant-files
-        - keystone-dsvm-functional-federation-centos7:
-            irrelevant-files: *irrelevant-files
-        - keystone-dsvm-functional-federation-ubuntu-xenial:
-            irrelevant-files: *irrelevant-files
-        - keystone-dsvm-py35-functional-federation-ubuntu-xenial:
-            irrelevant-files: *irrelevant-files

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -15,7 +15,6 @@
     parent: devstack-tempest
     timeout: 4200
     required-projects:
-      - openstack/devstack-gate
       - openstack/keystone
       - openstack/keystone-tempest-plugin
     vars:

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -16,7 +16,8 @@
     timeout: 4200
     required-projects:
       - openstack/keystone
-      - openstack/keystone-tempest-plugin
+      - name: openstack/keystone-tempest-plugin
+        override-checkout: wallaby-last
     vars:
       tox_envlist: all
       tempest_test_regex: 'keystone_tempest_plugin'

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -35,10 +35,12 @@
 - job:
     name: keystone-dsvm-py3-functional-fips
     parent: keystone-dsvm-py3-functional
-    nodeset: devstack-single-node-centos-8-stream
+    nodeset: devstack-single-node-centos-9-stream
     description: |
-      Functional testing for a FIPS enabled Centos 8 system
+      Functional testing for a FIPS enabled Centos 9 system
     pre-run: playbooks/enable-fips.yaml
+    vars:
+      nslookup_target: 'opendev.org'
 
 - job:
     name: keystone-dsvm-functional-federation-opensuse15

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -203,7 +203,7 @@
 - project:
     templates:
       - openstack-cover-jobs
-      - openstack-python3-xena-jobs
+      - openstack-python3-yoga-jobs
       - publish-openstack-docs-pti
       - periodic-stable-jobs
       - check-requirements

--- a/doc/source/admin/integrate-with-ldap.inc
+++ b/doc/source/admin/integrate-with-ldap.inc
@@ -68,14 +68,32 @@ Define the destination LDAP server in the ``/etc/keystone/keystone.conf`` file:
    suffix = dc=example,dc=org
 
 
-Multiple LDAP servers can be supplied to ``url`` to provide high-availability
-support for a single LDAP backend. To specify multiple LDAP servers, simply
-change the ``url`` option in the ``[ldap]`` section to be a list, separated by
-commas:
+Although it's not recommended (see note below), multiple LDAP servers can be
+supplied to ``url`` to provide high-availability support for a single LDAP
+backend. By default, these will be tried in order of apperance, but an
+additional option, ``randomize_urls`` can be set to true, to randomize the
+list in each process (when it starts). To specify multiple LDAP servers,
+simply change the ``url`` option in the ``[ldap]`` section to be a list,
+separated by commas:
 
 .. code-block:: ini
 
    url = "ldap://localhost,ldap://backup.localhost"
+   randomize_urls = true
+
+.. NOTE::
+
+    Failover mechanisms in the LDAP backend can cause delays when switching
+    over to the next working LDAP server. Randomizing the order in which the
+    servers are tried only makes the failure behavior not dependent on which
+    of the ordered servers fail. Individual processes can still be delayed or
+    time out, so this doesn't fix the issue at hand, but only makes the
+    failure mode more gradual. This behavior cannot be easily fixed inside the
+    service, because keystone would have to monitor the status of each LDAP
+    server, which is in fact a task for a load balancer. Because of this, it
+    is recommended to use a load balancer in front of the LDAP servers,
+    which can monitor the state of the cluster and instantly redirect
+    connections to the working LDAP server.
 
 **Additional LDAP integration settings**
 

--- a/doc/source/install/index-obs.rst
+++ b/doc/source/install/index-obs.rst
@@ -12,14 +12,6 @@ both SP1 and SP2 - through the Open Build Service Cloud repository.
 Explanations of configuration options and sample configuration files
 are included.
 
-.. note::
-   The Training Labs scripts provide an automated way of deploying the
-   cluster described in this Installation Guide into VirtualBox or KVM
-   VMs. You will need a desktop computer or a laptop with at least 8
-   GB memory and 20 GB free storage running Linux, MacOS, or Windows.
-   Please see the
-   `OpenStack Training Labs <https://docs.openstack.org/training_labs/>`_.
-
 .. warning::
 
    This guide is a work-in-progress and is subject to updates frequently.

--- a/doc/source/install/index-rdo.rst
+++ b/doc/source/install/index-rdo.rst
@@ -12,14 +12,6 @@ the RDO repository.
 Explanations of configuration options and sample configuration files
 are included.
 
-.. note::
-   The Training Labs scripts provide an automated way of deploying the
-   cluster described in this Installation Guide into VirtualBox or KVM
-   VMs. You will need a desktop computer or a laptop with at least 8
-   GB memory and 20 GB free storage running Linux, MacOS, or Windows.
-   Please see the
-   `OpenStack Training Labs <https://docs.openstack.org/training_labs/>`_.
-
 .. warning::
 
    This guide is a work-in-progress and is subject to updates frequently.

--- a/doc/source/install/index-ubuntu.rst
+++ b/doc/source/install/index-ubuntu.rst
@@ -12,14 +12,6 @@ Ubuntu 16.04 (LTS).
 Explanations of configuration options and sample configuration files
 are included.
 
-.. note::
-   The Training Labs scripts provide an automated way of deploying the
-   cluster described in this Installation Guide into VirtualBox or KVM
-   VMs. You will need a desktop computer or a laptop with at least 8
-   GB memory and 20 GB free storage running Linux, MacOS, or Windows.
-   Please see the
-   `OpenStack Training Labs <https://docs.openstack.org/training_labs/>`_.
-
 .. warning::
 
    This guide is a work-in-progress and is subject to updates frequently.

--- a/keystone/api/ec2tokens.py
+++ b/keystone/api/ec2tokens.py
@@ -12,6 +12,8 @@
 
 # This file handles all flask-restful resources for /v3/ec2tokens
 
+import urllib.parse
+
 import flask
 import http.client
 from keystoneclient.contrib.ec2 import utils as ec2_utils
@@ -42,8 +44,8 @@ class EC2TokensResource(EC2_S3_Resource.ResourceBase):
             # NOTE(vish): Some client libraries don't use the port when
             # signing requests, so try again without the port.
             elif ':' in credentials['host']:
-                hostname, _port = credentials.split(':')
-                credentials['host'] = hostname
+                parsed = urllib.parse.urlsplit('//' + credentials['host'])
+                credentials['host'] = parsed.hostname
                 # NOTE(davechen): we need to reinitialize 'signer' to avoid
                 # contaminated status of signature, this is similar with
                 # other programming language libraries, JAVA for example.

--- a/keystone/api/users.py
+++ b/keystone/api/users.py
@@ -387,6 +387,8 @@ class UserOSEC2CredentialsResourceListCreate(_UserOSEC2CredBaseResource):
         target['credential'] = {'user_id': user_id}
         ENFORCER.enforce_call(action='identity:ec2_create_credential',
                               target_attr=target)
+        token = self.auth_context['token']
+        _check_unrestricted_application_credential(token)
         PROVIDERS.identity_api.get_user(user_id)
         tenant_id = self.request_body_json.get('tenant_id')
         PROVIDERS.resource_api.get_project(tenant_id)

--- a/keystone/assignment/core.py
+++ b/keystone/assignment/core.py
@@ -938,6 +938,7 @@ class Manager(manager.Manager):
 
         return assignments
 
+    @MEMOIZE_COMPUTED_ASSIGNMENTS
     def list_role_assignments(self, role_id=None, user_id=None, group_id=None,
                               system=None, domain_id=None, project_id=None,
                               include_subtree=False, inherited=None,
@@ -1080,6 +1081,7 @@ class Manager(manager.Manager):
         system_assignments = self.list_system_grants_for_group(group_id)
         for assignment in system_assignments:
             self.delete_system_grant_for_group(group_id, assignment['id'])
+        COMPUTED_ASSIGNMENTS_REGION.invalidate()
 
     def delete_user_assignments(self, user_id):
         # FIXME(lbragstad): This should be refactored in the Rocky release so
@@ -1091,6 +1093,7 @@ class Manager(manager.Manager):
         system_assignments = self.list_system_grants_for_user(user_id)
         for assignment in system_assignments:
             self.delete_system_grant_for_user(user_id, assignment['id'])
+        COMPUTED_ASSIGNMENTS_REGION.invalidate()
 
     def check_system_grant_for_user(self, user_id, role_id):
         """Check if a user has a specific role on the system.
@@ -1163,6 +1166,7 @@ class Manager(manager.Manager):
         target_id = self._SYSTEM_SCOPE_TOKEN
         inherited = False
         self.driver.delete_system_grant(role_id, user_id, target_id, inherited)
+        COMPUTED_ASSIGNMENTS_REGION.invalidate()
 
     def check_system_grant_for_group(self, group_id, role_id):
         """Check if a group has a specific role on the system.
@@ -1237,6 +1241,7 @@ class Manager(manager.Manager):
         self.driver.delete_system_grant(
             role_id, group_id, target_id, inherited
         )
+        COMPUTED_ASSIGNMENTS_REGION.invalidate()
 
     def list_all_system_grants(self):
         """Return a list of all system grants."""

--- a/keystone/common/policies/base.py
+++ b/keystone/common/policies/base.py
@@ -59,6 +59,10 @@ SYSTEM_ADMIN_OR_CRED_OWNER = (
     '(' + SYSTEM_ADMIN + ') '
     'or user_id:%(target.credential.user_id)s'
 )
+ADMIN_OR_MEMBER_AND_CRED_OWNER = (
+    '(' + RULE_ADMIN_REQUIRED + ') or '
+    '(role:member and user_id:%(target.credential.user_id)s)'
+)
 
 rules = [
     policy.RuleDefault(

--- a/keystone/common/policies/ec2_credential.py
+++ b/keystone/common/policies/ec2_credential.py
@@ -67,7 +67,7 @@ ec2_credential_policies = [
     ),
     policy.DocumentedRuleDefault(
         name=base.IDENTITY % 'ec2_create_credential',
-        check_str=base.RULE_SYSTEM_ADMIN_OR_OWNER,
+        check_str=base.ADMIN_OR_MEMBER_AND_CRED_OWNER,
         scope_types=['system', 'project'],
         description='Create ec2 credential.',
         operations=[{'path': '/v3/users/{user_id}/credentials/OS-EC2',
@@ -76,7 +76,7 @@ ec2_credential_policies = [
     ),
     policy.DocumentedRuleDefault(
         name=base.IDENTITY % 'ec2_delete_credential',
-        check_str=base.SYSTEM_ADMIN_OR_CRED_OWNER,
+        check_str=base.ADMIN_OR_MEMBER_AND_CRED_OWNER,
         scope_types=['system', 'project'],
         description='Delete ec2 credential.',
         operations=[{'path': ('/v3/users/{user_id}/credentials/OS-EC2/'

--- a/keystone/conf/identity.py
+++ b/keystone/conf/identity.py
@@ -99,7 +99,11 @@ max_password_length = cfg.IntOpt(
     max=passlib.utils.MAX_PASSWORD_SIZE,
     help=utils.fmt("""
 Maximum allowed length for user passwords. Decrease this value to improve
-performance. Changing this value does not effect existing passwords.
+performance. Changing this value does not effect existing passwords. This value
+can also be overridden by certain hashing algorithms maximum allowed length
+which takes precedence over the configured value.
+
+The bcrypt max_password_length is 72 bytes.
 """))
 
 list_limit = cfg.IntOpt(

--- a/keystone/conf/ldap.py
+++ b/keystone/conf/ldap.py
@@ -24,6 +24,18 @@ as a comma separated string. The first URL to successfully bind is used for the
 connection.
 """))
 
+randomize_urls = cfg.BoolOpt(
+    'randomize_urls',
+    default=False,
+    help=utils.fmt("""
+Randomize the order of URLs in each keystone process. This makes the failure
+behavior more gradual, since if the first server is down, a process/thread
+will wait for the specified timeout before attempting a connection to a
+server further down the list. This defaults to False, for backward
+compatibility.
+"""))
+
+
 user = cfg.StrOpt(
     'user',
     help=utils.fmt("""
@@ -479,6 +491,7 @@ use_auth_pool` is also enabled.
 GROUP_NAME = __name__.split('.')[-1]
 ALL_OPTS = [
     url,
+    randomize_urls,
     user,
     password,
     suffix,

--- a/keystone/identity/backends/ldap/common.py
+++ b/keystone/identity/backends/ldap/common.py
@@ -15,6 +15,7 @@
 import abc
 import codecs
 import os.path
+import random
 import re
 import sys
 import uuid
@@ -1166,7 +1167,12 @@ class BaseLdap(object):
     tree_dn = None
 
     def __init__(self, conf):
-        self.LDAP_URL = conf.ldap.url
+        if conf.ldap.randomize_urls:
+            urls = re.split(r'[\s,]+', conf.ldap.url)
+            random.shuffle(urls)
+            self.LDAP_URL = ','.join(urls)
+        else:
+            self.LDAP_URL = conf.ldap.url
         self.LDAP_USER = conf.ldap.user
         self.LDAP_PASSWORD = conf.ldap.password
         self.LDAP_SCOPE = ldap_scope(conf.ldap.query_scope)

--- a/keystone/models/revoke_model.py
+++ b/keystone/models/revoke_model.py
@@ -242,8 +242,9 @@ def build_token_values(token):
         token_values['assignment_domain_id'] = None
 
     role_list = []
-    if token.roles is not None:
-        for role in token.roles:
+    token_roles = token.roles
+    if token_roles is not None:
+        for role in token_roles:
             role_list.append(role['id'])
     token_values['roles'] = role_list
 

--- a/keystone/tests/unit/assignment/test_backends.py
+++ b/keystone/tests/unit/assignment/test_backends.py
@@ -643,6 +643,9 @@ class AssignmentTests(AssignmentTestHelperMixin):
         # attempts to lookup a group that has been deleted in the backend
         with mock.patch.object(PROVIDERS.identity_api, 'get_group',
                                _group_not_found):
+            # Mocking a dependent function makes the cache invalid
+            keystone.assignment.COMPUTED_ASSIGNMENTS_REGION.invalidate()
+
             assignment_list = PROVIDERS.assignment_api.list_role_assignments(
                 include_names=True
             )
@@ -669,6 +672,9 @@ class AssignmentTests(AssignmentTestHelperMixin):
         # in the backend
         with mock.patch.object(PROVIDERS.identity_api, 'list_users_in_group',
                                _group_not_found):
+            # Mocking a dependent function makes the cache invalid
+            keystone.assignment.COMPUTED_ASSIGNMENTS_REGION.invalidate()
+
             assignment_list = PROVIDERS.assignment_api.list_role_assignments(
                 effective=True
             )

--- a/keystone/tests/unit/common/test_utils.py
+++ b/keystone/tests/unit/common/test_utils.py
@@ -77,7 +77,7 @@ class UtilsTestCase(unit.BaseTestCase):
         self.config_fixture.config(strict_password_check=False)
         password = uuid.uuid4().hex
         verified = common_utils.verify_length_and_trunc_password(password)
-        self.assertEqual(password, verified)
+        self.assertEqual(password.encode('utf-8'), verified)
 
     def test_that_a_hash_can_not_be_validated_against_a_hash(self):
         # NOTE(dstanek): Bug 1279849 reported a problem where passwords
@@ -97,7 +97,7 @@ class UtilsTestCase(unit.BaseTestCase):
         max_length = CONF.identity.max_password_length
         invalid_password = 'passw0rd'
         trunc = common_utils.verify_length_and_trunc_password(invalid_password)
-        self.assertEqual(invalid_password[:max_length], trunc)
+        self.assertEqual(invalid_password.encode('utf-8')[:max_length], trunc)
 
     def test_verify_long_password_strict_raises_exception(self):
         self.config_fixture.config(strict_password_check=True)
@@ -130,6 +130,17 @@ class UtilsTestCase(unit.BaseTestCase):
     def test_hash_long_password_strict(self):
         self.config_fixture.config(strict_password_check=True)
         invalid_length_password = '0' * 9999999
+        self.assertRaises(exception.PasswordVerificationError,
+                          common_utils.hash_password,
+                          invalid_length_password)
+
+    def test_max_algo_length_truncates_password(self):
+        self.config_fixture.config(strict_password_check=True)
+        self.config_fixture.config(group='identity',
+                                   password_hash_algorithm='bcrypt')
+        self.config_fixture.config(group='identity',
+                                   max_password_length='96')
+        invalid_length_password = '0' * 96
         self.assertRaises(exception.PasswordVerificationError,
                           common_utils.hash_password,
                           invalid_length_password)

--- a/keystone/tests/unit/fakeldap.py
+++ b/keystone/tests/unit/fakeldap.py
@@ -296,6 +296,9 @@ class FakeLdap(common.LDAPHandler):
             raise ldap.SERVER_DOWN
         whos = ['cn=Admin', CONF.ldap.user]
         if (who in whos and cred in ['password', CONF.ldap.password]):
+            self.connected = True
+            self.who = who
+            self.cred = cred
             return
 
         attrs = self.db.get(self.key(who))
@@ -316,6 +319,9 @@ class FakeLdap(common.LDAPHandler):
 
     def unbind_s(self):
         """Provide for compatibility but this method is ignored."""
+        self.connected = False
+        self.who = None
+        self.cred = None
         if server_fail:
             raise ldap.SERVER_DOWN
 
@@ -534,7 +540,7 @@ class FakeLdap(common.LDAPHandler):
             raise exception.NotImplemented()
 
         # only passing a single server control is supported by this fake ldap
-        if len(serverctrls) > 1:
+        if serverctrls and len(serverctrls) > 1:
             raise exception.NotImplemented()
 
         # search_ext is async and returns an identifier used for
@@ -589,6 +595,7 @@ class FakeLdapPool(FakeLdap):
     def __init__(self, uri, retry_max=None, retry_delay=None, conn=None):
         super(FakeLdapPool, self).__init__(conn=conn)
         self.url = uri
+        self._uri = uri
         self.connected = None
         self.conn = self
         self._connection_time = 5  # any number greater than 0

--- a/keystone/tests/unit/test_v3_auth.py
+++ b/keystone/tests/unit/test_v3_auth.py
@@ -5577,6 +5577,21 @@ class ApplicationCredentialAuth(test_v3.RestfulTestCase):
             self.v3_create_token(auth_data,
                                  expected_status=http.client.UNAUTHORIZED)
 
+    def test_application_credential_expiration_limits_token_expiration(self):
+        expires_at = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
+        app_cred = self._make_app_cred(expires=expires_at)
+        app_cred_ref = self.app_cred_api.create_application_credential(
+            app_cred)
+        auth_data = self.build_authentication_request(
+            app_cred_id=app_cred_ref['id'], secret=app_cred_ref['secret'])
+        resp = self.v3_create_token(auth_data,
+                                    expected_status=http.client.CREATED)
+        token = resp.headers.get('X-Subject-Token')
+        future = datetime.datetime.utcnow() + datetime.timedelta(minutes=2)
+        with freezegun.freeze_time(future):
+            self._validate_token(token,
+                                 expected_status=http.client.UNAUTHORIZED)
+
     def test_application_credential_fails_when_user_deleted(self):
         app_cred = self._make_app_cred()
         app_cred_ref = self.app_cred_api.create_application_credential(

--- a/keystone/tests/unit/token/test_fernet_provider.py
+++ b/keystone/tests/unit/token/test_fernet_provider.py
@@ -17,6 +17,8 @@ import os
 from unittest import mock
 import uuid
 
+import fixtures
+from oslo_log import log
 from oslo_utils import timeutils
 
 from keystone import auth
@@ -26,6 +28,7 @@ from keystone.common import utils
 import keystone.conf
 from keystone import exception
 from keystone.federation import constants as federation_constants
+from keystone.models import token_model
 from keystone.tests import unit
 from keystone.tests.unit import default_fixtures
 from keystone.tests.unit import ksfixtures
@@ -50,6 +53,59 @@ class TestFernetTokenProvider(unit.TestCase):
             exception.TokenNotFound,
             self.provider.validate_token,
             token_id)
+
+    def test_log_warning_when_token_exceeds_max_token_size_default(self):
+        self.logging = self.useFixture(fixtures.FakeLogger(level=log.INFO))
+
+        token = token_model.TokenModel()
+        token.user_id = '0123456789abcdef0123456789abcdef0123456789abcdef'
+        token.project_id = '0123456789abcdef0123456789abcdef0123456789abcdef'
+        token.expires_at = utils.isotime(
+            provider.default_expire_time(), subsecond=True)
+        token.methods = ['password']
+        token.audit_id = provider.random_urlsafe_str()
+        token_id, issued_at = self.provider.generate_id_and_issued_at(token)
+        expected_output = (
+            f'Fernet token created with length of {len(token_id)} characters, '
+            'which exceeds 255 characters'
+        )
+        self.assertIn(expected_output, self.logging.output)
+
+    def test_log_warning_when_token_exceeds_max_token_size_override(self):
+        self.logging = self.useFixture(fixtures.FakeLogger(level=log.INFO))
+        self.config_fixture.config(max_token_size=250)
+
+        token = token_model.TokenModel()
+        token.user_id = '0123456789abcdef0123456789abcdef0123456789abcdef'
+        token.project_id = '0123456789abcdef0123456789abcdef0123456789abcdef'
+        token.expires_at = utils.isotime(
+            provider.default_expire_time(), subsecond=True)
+        token.methods = ['password']
+        token.audit_id = provider.random_urlsafe_str()
+        token_id, issued_at = self.provider.generate_id_and_issued_at(token)
+        expected_output = (
+            f'Fernet token created with length of {len(token_id)} characters, '
+            'which exceeds 250 characters'
+        )
+        self.assertIn(expected_output, self.logging.output)
+
+    def test_no_warning_when_token_does_not_exceed_max_token_size(self):
+        self.config_fixture.config(max_token_size=300)
+        self.logging = self.useFixture(fixtures.FakeLogger(level=log.INFO))
+
+        token = token_model.TokenModel()
+        token.user_id = '0123456789abcdef0123456789abcdef0123456789abcdef'
+        token.project_id = '0123456789abcdef0123456789abcdef0123456789abcdef'
+        token.expires_at = utils.isotime(
+            provider.default_expire_time(), subsecond=True)
+        token.methods = ['password']
+        token.audit_id = provider.random_urlsafe_str()
+        token_id, issued_at = self.provider.generate_id_and_issued_at(token)
+        expected_output = (
+            f'Fernet token created with length of {len(token_id)} characters, '
+            'which exceeds 255 characters'
+        )
+        self.assertNotIn(expected_output, self.logging.output)
 
 
 class TestValidate(unit.TestCase):

--- a/keystone/token/provider.py
+++ b/keystone/token/provider.py
@@ -267,6 +267,23 @@ class Manager(manager.Manager):
                 default_expire_time(), subsecond=True
             )
 
+        # NOTE(d34dh0r53): If this token is being issued with an application
+        # credential and the application credential expires before the token
+        # we need to set the token expiration to be the same as the application
+        # credential. See CVE-2022-2447 for more information.
+        if app_cred_id is not None:
+            app_cred_api = PROVIDERS.application_credential_api
+            app_cred = app_cred_api.get_application_credential(
+                token.application_credential_id)
+            token_time = timeutils.normalize_time(
+                timeutils.parse_isotime(token.expires_at))
+            if (app_cred['expires_at'] is not None) and (
+                    token_time > app_cred['expires_at']):
+                token.expires_at = app_cred['expires_at'].isoformat()
+                LOG.debug('Resetting token expiration to the application'
+                          ' credential expiration: %s',
+                          app_cred['expires_at'].isoformat())
+
         token_id, issued_at = self.driver.generate_id_and_issued_at(token)
         token.mint(token_id, issued_at)
 

--- a/keystone/token/token_formatters.py
+++ b/keystone/token/token_formatters.py
@@ -156,10 +156,11 @@ class TokenFormatter(object):
         # characters. Even though Keystone isn't storing a Fernet token
         # anywhere, we can't say it isn't being stored somewhere else with
         # those kind of backend constraints.
-        if len(token) > 255:
-            LOG.info('Fernet token created with length of %d '
-                     'characters, which exceeds 255 characters',
-                     len(token))
+        if len(token) > CONF.max_token_size:
+            LOG.info(
+                f'Fernet token created with length of {len(token)} '
+                f'characters, which exceeds {CONF.max_token_size} characters',
+            )
 
         return token
 

--- a/releasenotes/notes/bcrypt_truncation_fix-674dc5d7f1e776f2.yaml
+++ b/releasenotes/notes/bcrypt_truncation_fix-674dc5d7f1e776f2.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Passwords that are hashed using bcrypt are now truncated properly to the
+    maximum allowed length by the algorythm. This solves regression, when
+    passwords longer then 54 symbols are getting invalidated after the
+    Keystone upgrade.

--- a/releasenotes/notes/bug-1926483-a77ab887e0e7f5c9.yaml
+++ b/releasenotes/notes/bug-1926483-a77ab887e0e7f5c9.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    [`bug 1926483 <https://bugs.launchpad.net/keystone/+bug/1926483>`_]
+    Keystone will only log warnings about token length for Fernet tokens when
+    the token length exceeds the value of `keystone.conf [DEFAULT]
+    max_token_size`.

--- a/releasenotes/notes/max-password-length-truncation-and-warning-bd69090315ec18a7.yaml
+++ b/releasenotes/notes/max-password-length-truncation-and-warning-bd69090315ec18a7.yaml
@@ -1,0 +1,9 @@
+---
+security:
+  - |
+    Passwords will now be automatically truncated if the max_password_length is
+    greater than the allowed length for the selected password hashing
+    algorithm. Currently only bcrypt has fixed allowed lengths defined which is
+    54 characters. A warning will be generated in the log if a password is
+    truncated.  This will not affect existing passwords, however only the first
+    54 characters of existing bcrypt passwords will be validated.

--- a/releasenotes/notes/randomize_urls-c0c19f48b2bfa299.yaml
+++ b/releasenotes/notes/randomize_urls-c0c19f48b2bfa299.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    A new option 'randomize_urls' can be used to randomize the order in which
+    keystone connects to the LDAP servers in [ldap] 'url' list.
+    It is false by default.

--- a/releasenotes/notes/token_expiration_to_match_application_credential-56d058355a9f240d.yaml
+++ b/releasenotes/notes/token_expiration_to_match_application_credential-56d058355a9f240d.yaml
@@ -1,0 +1,10 @@
+---
+security:
+  - |
+    [`bug 1992183 <https://bugs.launchpad.net/keystone/+bug/1992183>`_]
+    [`CVE-2022-2447 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2447>`_]
+    Tokens issued with application credentials will now have their expiration
+    validated against that of the application credential. If the application
+    credential expires before the token the token's expiration will be set to
+    the same expiration as the application credential.  Otherwise the token
+    will use the configured value.

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,11 @@
 minversion = 3.2.0
 envlist = py37,pep8,api-ref,docs,genconfig,genpolicy,releasenotes,protection
 ignore_basepython_conflict = true
+# Cap setuptools via virtualenv to prevent compatibility issue with yoga
+# branch's upper constraint of 'packaging' package (21.3).
+requires =
+  virtualenv<20.26.4
+  tox<4
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -119,6 +119,9 @@ enable-extensions = H203,H904
 ignore = D100,D101,D102,D103,D104,D203,E402,W503,W504
 exclude=.venv,.git,.tox,build,dist,*lib/python*,*egg,tools,vendor,.update-venv,*.ini,*.po,*.pot
 max-complexity=24
+per-file-ignores =
+# URL lines too long
+    keystone/common/password_hashing.py: E501
 
 [testenv:docs]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ usedevelop = True
 basepython = python3
 setenv = VIRTUAL_ENV={envdir}
 deps =
-  -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
   -r{toxinidir}/test-requirements.txt
   .[ldap,memcache,mongodb]
 commands =
@@ -42,7 +42,7 @@ passenv = FAST8_NUM_COMMITS
 # NOTE(browne): This is required for the integration test job of the bandit
 # project. Please do not remove.
 deps =
-  -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
   -r{toxinidir}/requirements.txt
   .[bandit]
 commands = bandit -r keystone -x 'keystone/tests/*'
@@ -84,7 +84,7 @@ passenv =
 
 [testenv:functional]
 deps =
-  -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
   -r{toxinidir}/test-requirements.txt
 setenv = OS_TEST_PATH=./keystone/tests/functional
 commands =
@@ -122,7 +122,7 @@ max-complexity=24
 
 [testenv:docs]
 deps =
-  -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
   -r{toxinidir}/doc/requirements.txt
   .[ldap,memcache,mongodb]
 commands=


### PR DESCRIPTION
Prevent unauthorized EC2 credential creation and deletion
A restricted application credential could be used to create EC2
credentials granting full user access to S3, bypassing the role
restriction. Add the same _check_unrestricted_application_credential
guard that already protects application credential create/delete
endpoints.

Additionally, tighten the ec2_create_credential and ec2_delete_credential
policies to require at least member role, as these are write operations
that should not be accessible to reader-role users regardless of whether
they are using an application credential.

Change-Id: Ib6904ec9f1bc069a9f607d39814b1d2633c17f53
Closes-Bug: #2142138
Signed-off-by: Grzegorz Grasza <xek@redhat.com>
(cherry picked from commit https://github.com/stackhpc/keystone-private/commit/34b7c572d065267bb31dbd6846aa48b9f11fe8c9)